### PR TITLE
Fix tiny_nerf_data.npz link

### DIFF
--- a/tiny_nerf.ipynb
+++ b/tiny_nerf.ipynb
@@ -67,23 +67,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2020-03-20 22:19:38--  https://people.eecs.berkeley.edu/~bmild/nerf/tiny_nerf_data.npz\n",
-      "Resolving people.eecs.berkeley.edu (people.eecs.berkeley.edu)... 128.32.189.73\n",
-      "Connecting to people.eecs.berkeley.edu (people.eecs.berkeley.edu)|128.32.189.73|:443... connected.\n",
+      "--2021-11-30 06:23:32--  http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz\n",
+      "Resolving cseweb.ucsd.edu (cseweb.ucsd.edu)... 132.239.8.30\n",
+      "Connecting to cseweb.ucsd.edu (cseweb.ucsd.edu)|132.239.8.30|:80... connected.\n",
+      "HTTP request sent, awaiting response... 302 Found\n",
+      "Location: https://cseweb.ucsd.edu//~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz [following]\n",
+      "--2021-11-30 06:23:32--  https://cseweb.ucsd.edu//~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz\n",
+      "Connecting to cseweb.ucsd.edu (cseweb.ucsd.edu)|132.239.8.30|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 12727482 (12M)\n",
-      "Saving to: ‘tiny_nerf_data.npz.2’\n",
+      "Saving to: ‘tiny_nerf_data.npz’\n",
       "\n",
-      "tiny_nerf_data.npz. 100%[===================>]  12.14M  7.43MB/s    in 1.6s    \n",
+      "tiny_nerf_data.npz  100%[===================>]  12.14M  20.5MB/s    in 0.6s    \n",
       "\n",
-      "2020-03-20 22:19:41 (7.43 MB/s) - ‘tiny_nerf_data.npz.2’ saved [12727482/12727482]\n",
+      "2021-11-30 06:23:33 (20.5 MB/s) - ‘tiny_nerf_data.npz’ saved [12727482/12727482]\n",
       "\n"
      ]
     }
    ],
    "source": [
     "if not os.path.exists('tiny_nerf_data.npz'):\n",
-    "    !wget https://people.eecs.berkeley.edu/~bmild/nerf/tiny_nerf_data.npz"
+    "    !wget http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz"
    ]
   },
   {


### PR DESCRIPTION
`tiny_nerf_data.npz` no longer seems to be available at https://people.eecs.berkeley.edu/~bmild/nerf/tiny_nerf_data.npz, which means tiny_nerf.ipynb no longer works out of the box.

https://github.com/bmild/nerf/commit/4edc1c201461c2fd945dad8eb631cc2522901ec4 suggests that the correct path is http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz, which appears to work.

This PR just changes the URL used by tiny_nerf.ipynb and the corresponding cell's output.